### PR TITLE
Drop manual 100vw width specifications

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -198,8 +198,7 @@ export default function App() {
           <Box
             sx={{
               display: { xs: "none", lg: "flex" },
-              width: "100vw",
-              flexDirection: { xs: "column", lg: "row" },
+              flexDirection: "row",
               alignItems: "center",
               justifyContent: "space-around",
               position: "sticky",
@@ -228,7 +227,6 @@ export default function App() {
           </Box>
           <Box
             sx={{
-              width: { xs: "100vw", lg: "auto" },
               display: { xs: "flex", lg: "none" },
               justifyContent: "center",
               backgroundColor: "rgba(46,46,46,0.9)",

--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -115,7 +115,7 @@ export default function Toolbar({ playing, setPlaying, displayedStations, volume
   return (
     <Box sx={{
       width: {
-        xs: "100vw",
+        xs: "100%",
         lg: "auto"
       },
       display: "flex",


### PR DESCRIPTION
There's a little bit of horizontal scroll going on with the desktop (not xs) view -- due to this `100vw` dictating the width. The vertical scrollbar which shows up on desktop (but not mobile) is causing this. We lose some width _but_ the vw unit doesn't change.

Fortunately dropping these statements just defaults it to 100%, which is what we want. I also dropped the width specification for lg on a Box that doesn't show on lg anyway.